### PR TITLE
[experimental] Save history for editor without file path

### DIFF
--- a/lib/entry.js
+++ b/lib/entry.js
@@ -69,7 +69,7 @@ module.exports = class Entry {
     if (this.isDestroyed()) return false
 
     const excludeClosedBuffer = atom.config.get("cursor-history.excludeClosedBuffer")
-    return this.isEditorAlive() || (!excludeClosedBuffer && existsSync(this.URI))
+    return this.isEditorAlive() || (!excludeClosedBuffer && this.URI && existsSync(this.URI))
   }
 
   isSameFile(other) {

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -26,13 +26,21 @@ module.exports = class Entry {
 
     this.editor = editor
     this.subscriptions = new CompositeDisposable()
-    this.marker = this.editor.markBufferPosition(this.point)
+    this.marker = editor.markBufferPosition(point)
     this.subscriptions.add(
       this.marker.onDidChange(({newHeadBufferPosition}) => {
         this.point = newHeadBufferPosition
       })
     )
-    this.subscriptions.add(this.editor.onDidDestroy(() => this.unSubscribe()))
+    this.subscriptions.add(
+      editor.onDidDestroy(() => {
+        if (editor.getURI()) {
+          this.unSubscribe()
+        } else {
+          this.destroy()
+        }
+      })
+    )
   }
 
   unSubscribe() {
@@ -40,7 +48,11 @@ module.exports = class Entry {
     this.editor = this.subscriptions = null
   }
 
+  // isAllowedisItemAllowed
+
   destroy() {
+    if (this.destroyed) return
+
     if (this.editor) this.unSubscribe()
     this.destroyed = true
     if (this.marker) this.marker.destroy()
@@ -51,23 +63,28 @@ module.exports = class Entry {
     return this.destroyed
   }
 
-  isValid() {
-    if (this.isDestroyed()) return false
-    if (
-      atom.config.get("cursor-history.excludeClosedBuffer") &&
-      !(this.editor && this.editor.isAlive())
-    ) {
-      return false
-    }
-    return existsSync(this.URI)
+  isEditorAlive() {
+    return this.editor && this.editor.isAlive()
   }
 
-  isAtSameRow(otherEntry) {
+  isValid() {
+    if (this.isDestroyed()) return false
+
+    const excludeClosedBuffer = atom.config.get("cursor-history.excludeClosedBuffer")
+    return this.isEditorAlive() || (!excludeClosedBuffer && existsSync(this.URI))
+  }
+
+  isSameFile(other) {
+    return (this.editor && this.editor === other.editor) || (this.URI && (this.URI && other.URI))
+  }
+
+  isAtSameRow(other) {
     return (
-      otherEntry.point != null &&
-      this.point != null &&
-      otherEntry.point.row === this.point.row &&
-      otherEntry.URI === this.URI
+      this.isSameFile(other) &&
+      this.isValid() &&
+      other.isValid() &&
+      other.point.row === this.point.row &&
+      other.URI === this.URI
     )
   }
 
@@ -79,9 +96,8 @@ module.exports = class Entry {
     if (this.isDestroyed()) {
       return "[Destroyed]"
     } else {
-      let s = `${this.point}, ${path.basename(this.URI)}`
-      if (!this.isValid()) s += " [Invalid]"
-      return s
+      const invalid = this.isValid() ? "" : " [Invalid]"
+      return `${this.point}, ${path.basename(this.URI)}` + invalid
     }
   }
 }

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -76,8 +76,12 @@ module.exports = class Entry {
   }
 
   inspect() {
-    let s = `${this.point}, ${path.basename(this.URI)}`
-    if (!this.isValid()) s += " [invalid]"
-    return s
+    if (this.isDestroyed()) {
+      return "[Destroyed]"
+    } else {
+      let s = `${this.point}, ${path.basename(this.URI)}`
+      if (!this.isValid()) s += " [Invalid]"
+      return s
+    }
   }
 }

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -48,8 +48,6 @@ module.exports = class Entry {
     this.editor = this.subscriptions = null
   }
 
-  // isAllowedisItemAllowed
-
   destroy() {
     if (this.destroyed) return
 

--- a/lib/history.js
+++ b/lib/history.js
@@ -58,20 +58,29 @@ module.exports = class History {
     this.index = this.entries = this.configObserver = null
   }
 
-  findValidEntry(direction, {URI} = {}) {
-    const isValid = entry => entry.isValid() && (URI ? entry.URI === URI : true)
+  find(direction, editor) {
+    const isValid = entry => {
+      if (!entry.isValid()) return false
+
+      if (editor) {
+        const valid = entry.URI ? entry.URI === editor.getURI() : entry.editor === editor
+        if (!valid) return false
+      }
+
+      const searchAllPanes = atom.config.get("cursor-history.searchAllPanes")
+      if (!searchAllPanes) {
+        // When entry have URI we can open on any pane.
+        // If not, it's editor must be already exist in current pane.
+        const valid = entry.URI || atom.workspace.getActivePane().getItems().includes(entry.editor)
+        if (!valid) return false
+      }
+      return true
+    }
+
     if (direction === "next") {
       return this.entries.slice(this.index + 1).find(isValid)
     } else {
       return this.entries.slice(0, Math.max(this.index, 0)).reverse().find(isValid)
-    }
-  }
-
-  get(direction, options = {}) {
-    const entry = this.findValidEntry(direction, options)
-    if (entry) {
-      this.index = this.entries.indexOf(entry)
-      return entry
     }
   }
 
@@ -141,7 +150,6 @@ module.exports = class History {
   //
   add(location, {setIndexToHead = true, message} = {}) {
     const newEntry = new Entry(location)
-    let entry
     if (atom.config.get("cursor-history.keepSingleEntryPerBuffer")) {
       const isSameURI = entry => newEntry.URI === entry.URI
       this.entries.filter(isSameURI).forEach(destroyEntry)
@@ -151,6 +159,7 @@ module.exports = class History {
     }
 
     this.entries.push(newEntry)
+
     if (setIndexToHead) {
       this.setIndexToHead()
     }
@@ -214,17 +223,19 @@ module.exports = class History {
   }
 
   jump(editor, direction, {withinEditor} = {}) {
-    this.destroyDuplicateEntries()
-
     const origialURI = editor.getPath()
     const wasAtHead = this.isIndexAtHead()
-    const getOptions = withinEditor ? {URI: origialURI} : {}
-    const entry = this.get(direction, getOptions)
-    if (entry == null) return
+    const searchAllPanes = atom.config.get("cursor-history.searchAllPanes")
+
+    this.destroyDuplicateEntries()
+    const entry = this.find(direction, withinEditor ? editor : undefined)
+    if (!entry) return
+
+    this.index = this.entries.indexOf(entry)
 
     // FIXME, Explicitly preserve point, URI by setting independent value,
     // since its might be set null if entry.isAtSameRow()
-    const {point, URI} = entry
+    const copiedEntry = Object.assign({}, entry)
 
     if (direction === "prev" && wasAtHead) {
       const location = {
@@ -232,13 +243,27 @@ module.exports = class History {
         point: editor.getCursorBufferPosition(),
         URI: origialURI,
       }
-
       this.add(location, {setIndexToHead: false})
     }
 
-    const searchAllPanes = atom.config.get("cursor-history.searchAllPanes")
-    atom.workspace.open(URI, {searchAllPanes}).then(editor => {
-      this.land(editor, point, direction, origialURI === URI)
+    const currentPane = atom.workspace.paneForItem(editor)
+
+    if (copiedEntry.editor && !copiedEntry.URI) {
+      const pane = atom.workspace.getCenter().paneForItem(copiedEntry.editor)
+      if (!pane) {
+        throw new Error(`no pane found for ${editor}`)
+        this.log("NO PANE FOUND")
+        entry.destroy()
+        return
+      }
+      pane.activate()
+      pane.activateItem(copiedEntry.editor)
+      this.land(copiedEntry.editor, copiedEntry.point, direction, true)
+      return
+    }
+
+    atom.workspace.open(copiedEntry.URI, {searchAllPanes}).then(editor => {
+      this.land(editor, copiedEntry.point, direction, origialURI === copiedEntry.URI)
     })
   }
 

--- a/lib/history.js
+++ b/lib/history.js
@@ -217,8 +217,9 @@ module.exports = class History {
   jump(editor, direction, {withinEditor} = {}) {
     this.destroyDuplicateEntries()
 
+    const origialURI = editor.getPath()
     const wasAtHead = this.isIndexAtHead()
-    const getOptions = withinEditor ? {URI: editor.getURI()} : {}
+    const getOptions = withinEditor ? {URI: origialURI} : {}
     const entry = this.get(direction, getOptions)
     if (entry == null) return
 
@@ -231,32 +232,19 @@ module.exports = class History {
       this.add(location, {setIndexToHead: false, log: false, subject: "Save head position"})
     }
 
-    if (editor.getURI() === URI) {
-      this.land(editor, point, direction)
-      return
-    }
-
-    const activePane = atom.workspace.getActivePane()
-    const item = activePane.itemForURI(URI)
-    if (item) {
-      activePane.activateItem(item)
-      this.land(item, point, direction, {flash: true})
-      return
-    }
-
     const searchAllPanes = atom.config.get("cursor-history.searchAllPanes")
     atom.workspace.open(URI, {searchAllPanes}).then(editor => {
-      this.land(editor, point, direction, {flash: true})
+      this.land(editor, point, direction, origialURI === URI)
     })
   }
 
-  land(editor, point, direction, {flash} = {}) {
+  land(editor, point, direction, isSameURI) {
     const originalRow = editor.getCursorBufferPosition().row
     editor.setCursorBufferPosition(point, {autoscroll: false})
     editor.scrollToCursorPosition({center: true})
 
     if (atom.config.get("cursor-history.flashOnLand")) {
-      if (flash || point.row !== editor.getCursorBufferPosition().row) {
+      if (!isSameURI || originalRow !== point.row) {
         this.flash(editor)
       }
     }

--- a/lib/history.js
+++ b/lib/history.js
@@ -1,5 +1,7 @@
 const Entry = require("./entry")
 
+let createLocation // set by History.initialize
+
 const destroyEntry = entry => entry.destroy()
 const isValidEntry = entry => entry.isValid()
 const isNotValidEntry = entry => !entry.isValid()
@@ -12,7 +14,11 @@ module.exports = class History {
     }
   }
 
-  static deserialize(createLocation, state) {
+  static initialize(_createLocation) {
+    createLocation = _createLocation
+  }
+
+  static deserialize(state) {
     const editorByURI = {}
     const complementEditor = function(entry) {
       const {URI} = entry
@@ -24,14 +30,13 @@ module.exports = class History {
       return entry
     }
 
-    return Object.assign(new this(createLocation), {
+    return Object.assign(new this(), {
       index: state.index,
       entries: state.entries.map(complementEditor).map(entry => Entry.deserialize(entry)),
     })
   }
 
-  constructor(createLocation) {
-    this.createLocation = createLocation
+  constructor() {
     this.flashMarker = null
 
     this.init()
@@ -228,7 +233,7 @@ module.exports = class History {
     const {point, URI} = entry
 
     if (direction === "prev" && wasAtHead) {
-      const location = this.createLocation(editor, "prev")
+      const location = createLocation(editor, "prev")
       this.add(location, {setIndexToHead: false, log: false, subject: "Save head position"})
     }
 

--- a/lib/history.js
+++ b/lib/history.js
@@ -1,7 +1,5 @@
 const Entry = require("./entry")
 
-let createLocation // set by History.initialize
-
 const destroyEntry = entry => entry.destroy()
 const isValidEntry = entry => entry.isValid()
 const isNotValidEntry = entry => !entry.isValid()
@@ -12,10 +10,6 @@ module.exports = class History {
       index: this.index,
       entries: this.entries.filter(isValidEntry).map(e => e.serialize()),
     }
-  }
-
-  static initialize(_createLocation) {
-    createLocation = _createLocation
   }
 
   static deserialize(state) {
@@ -86,6 +80,9 @@ module.exports = class History {
   }
 
   setIndexToHead() {
+    // Since we know we can set index at entries.length, we can safely remove invalid entries here.
+    this.removeInvalidEntries()
+
     this.index = this.entries.length
     return this.index
   }
@@ -154,9 +151,7 @@ module.exports = class History {
     }
 
     this.entries.push(newEntry)
-    // Only when we are allowed to modify index, we can safely remove this.entries.
     if (setIndexToHead) {
-      this.removeInvalidEntries()
       this.setIndexToHead()
     }
     if (atom.config.get("cursor-history.debug") && message) {
@@ -174,7 +169,6 @@ module.exports = class History {
         URIs.add(entry.URI)
       }
     }
-    this.removeInvalidEntries()
     this.setIndexToHead()
   }
 
@@ -233,7 +227,13 @@ module.exports = class History {
     const {point, URI} = entry
 
     if (direction === "prev" && wasAtHead) {
-      this.add(createLocation(editor, "prev"), {setIndexToHead: false})
+      const location = {
+        editor,
+        point: editor.getCursorBufferPosition(),
+        URI: origialURI,
+      }
+
+      this.add(location, {setIndexToHead: false})
     }
 
     const searchAllPanes = atom.config.get("cursor-history.searchAllPanes")

--- a/lib/history.js
+++ b/lib/history.js
@@ -142,7 +142,7 @@ module.exports = class History {
   //    newEntry(row=7) is appended to end of @entries.
   //    No special @index adjustment.
   //
-  add(location, {subject, setIndexToHead = true, log = true} = {}) {
+  add(location, {setIndexToHead = true, message} = {}) {
     const newEntry = new Entry(location)
     let entry
     if (atom.config.get("cursor-history.keepSingleEntryPerBuffer")) {
@@ -159,8 +159,8 @@ module.exports = class History {
       this.removeInvalidEntries()
       this.setIndexToHead()
     }
-    if (atom.config.get("cursor-history.debug") && log) {
-      this.log(`${subject} [${location.type}]`)
+    if (atom.config.get("cursor-history.debug") && message) {
+      this.log(message)
     }
   }
 
@@ -233,8 +233,7 @@ module.exports = class History {
     const {point, URI} = entry
 
     if (direction === "prev" && wasAtHead) {
-      const location = createLocation(editor, "prev")
-      this.add(location, {setIndexToHead: false, log: false, subject: "Save head position"})
+      this.add(createLocation(editor, "prev"), {setIndexToHead: false})
     }
 
     const searchAllPanes = atom.config.get("cursor-history.searchAllPanes")

--- a/lib/main.js
+++ b/lib/main.js
@@ -7,12 +7,9 @@ const DefaultIgnoreCommands = [
   "cursor-history:clear",
 ]
 
-const closestTextEditorHavingURI = function(target) {
+function getClosestEditorForTarget(target) {
   if (!target || !target.closest("atom-text-editor")) return
-  const editor = target.closest("atom-text-editor").getModel()
-  if (editor && editor.getURI()) {
-    return editor
-  }
+  return target.closest("atom-text-editor").getModel()
 }
 
 function createLocation(editor, command) {
@@ -105,7 +102,7 @@ module.exports = {
     }
 
     const handleCapture = function(event) {
-      const editor = closestTextEditorHavingURI(event.target)
+      const editor = getClosestEditorForTarget(event.target)
       if (editor) {
         // In case, mousedown event was not **bubbled** up, detect location change
         // by comparing old and new location after 300ms
@@ -155,7 +152,7 @@ module.exports = {
 
     const disposableForWillDispatch = atom.commands.onWillDispatch(({type, target}) => {
       if (!isInterestingCommand(type)) return
-      const editor = closestTextEditorHavingURI(target)
+      const editor = getClosestEditorForTarget(target)
       if (editor) {
         if (!trackThrottlingTimeout) {
           locationStack.push(createLocation(editor, type))
@@ -167,7 +164,7 @@ module.exports = {
     const disposableForDidDispatch = atom.commands.onDidDispatch(({type, target}) => {
       if (!locationStack.length) return
       if (!isInterestingCommand(type)) return
-      if (closestTextEditorHavingURI(target)) {
+      if (getClosestEditorForTarget(target)) {
         // To wait cursor position is set on final destination.
         setTimeout(() => {
           this.checkLocationChange(locationStack.pop())
@@ -184,7 +181,8 @@ module.exports = {
     const editor = atom.workspace.getActiveTextEditor()
     if (!editor) return
 
-    if (!editor.element.hasFocus() || editor.getURI() !== oldLocation.URI) {
+    // if (!editor.element.hasFocus())  || editor.getURI() !== oldLocation.URI) {
+    if (!editor.element.hasFocus() || editor !== oldLocation.editor) {
       this.getHistory().add(oldLocation, {message: `Save on focus lost [${oldLocation.command}]`})
       return
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -82,7 +82,6 @@ module.exports = {
   getHistory() {
     if (!this.history) {
       History = require("./history")
-      History.initialize(createLocation)
       this.history = (this.restoredState ? this.restoredState.history : undefined)
         ? History.deserialize(this.restoredState.history)
         : new History()

--- a/lib/main.js
+++ b/lib/main.js
@@ -83,11 +83,14 @@ module.exports = {
 
   getHistory() {
     if (this.history) return this.history
-    if (History == null) History = require("./history")
+    if (History == null) {
+      History = require("./history")
+      History.initialize(createLocation)
+    }
 
     this.history = (this.restoredState ? this.restoredState.history : undefined)
-      ? History.deserialize(createLocation, this.restoredState.history)
-      : new History(createLocation)
+      ? History.deserialize(this.restoredState.history)
+      : new History()
 
     return this.history
   },

--- a/lib/main.js
+++ b/lib/main.js
@@ -190,7 +190,7 @@ module.exports = {
     if (!editor) return
 
     if (!editor.element.hasFocus() || editor.getURI() !== oldLocation.URI) {
-      this.getHistory().add(oldLocation, {subject: "Save on focus lost"})
+      this.getHistory().add(oldLocation, {message: `Save on focus lost [${oldLocation.type}]`})
       return
     }
 
@@ -205,7 +205,7 @@ module.exports = {
       row > atom.config.get("cursor-history.rowDeltaToRemember") ||
       (row === 0 && column > atom.config.get("cursor-history.columnDeltaToRemember"))
     ) {
-      this.getHistory().add(oldLocation, {subject: "Cursor moved"})
+      this.getHistory().add(oldLocation, {message: `Cursor moved [${oldLocation.type}]`})
     }
   },
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,4 @@
 const {CompositeDisposable, Disposable} = require("atom")
-let History = null
-
 const DefaultIgnoreCommands = [
   "cursor-history:next",
   "cursor-history:prev",
@@ -82,15 +80,13 @@ module.exports = {
   },
 
   getHistory() {
-    if (this.history) return this.history
-    if (History == null) {
+    if (!this.history) {
       History = require("./history")
       History.initialize(createLocation)
+      this.history = (this.restoredState ? this.restoredState.history : undefined)
+        ? History.deserialize(this.restoredState.history)
+        : new History()
     }
-
-    this.history = (this.restoredState ? this.restoredState.history : undefined)
-      ? History.deserialize(this.restoredState.history)
-      : new History()
 
     return this.history
   },

--- a/lib/main.js
+++ b/lib/main.js
@@ -15,9 +15,9 @@ const closestTextEditorHavingURI = function(target) {
   }
 }
 
-function createLocation(editor, type) {
+function createLocation(editor, command) {
   return {
-    type,
+    command,
     editor,
     point: editor.getCursorBufferPosition(),
     URI: editor.getURI(),
@@ -140,7 +140,7 @@ module.exports = {
   },
 
   observeCommands() {
-    let trackLocationTimeout
+    let trackThrottlingTimeout
     const locationStack = []
     this.locationStackForTestSpec = locationStack // expose to make test easy
 
@@ -148,24 +148,20 @@ module.exports = {
       return type.includes(":") && !this.ignoreCommands.includes(type)
     }
 
-    const resetTrackingDelay = function() {
-      clearTimeout(trackLocationTimeout)
-      trackLocationTimeout = null
-    }
-
-    const trackLocationChangeEdgeDebounced = function(type, editor) {
-      if (trackLocationTimeout) {
-        resetTrackingDelay()
-      } else {
-        locationStack.push(createLocation(editor, type))
-      }
-      trackLocationTimeout = setTimeout(resetTrackingDelay, 100)
+    const clearThrottling = function() {
+      clearTimeout(trackThrottlingTimeout)
+      trackThrottlingTimeout = null
     }
 
     const disposableForWillDispatch = atom.commands.onWillDispatch(({type, target}) => {
       if (!isInterestingCommand(type)) return
       const editor = closestTextEditorHavingURI(target)
-      if (editor) trackLocationChangeEdgeDebounced(type, editor)
+      if (editor) {
+        if (!trackThrottlingTimeout) {
+          locationStack.push(createLocation(editor, type))
+        }
+        trackThrottlingTimeout = setTimeout(clearThrottling, 100)
+      }
     })
 
     const disposableForDidDispatch = atom.commands.onDidDispatch(({type, target}) => {
@@ -189,7 +185,7 @@ module.exports = {
     if (!editor) return
 
     if (!editor.element.hasFocus() || editor.getURI() !== oldLocation.URI) {
-      this.getHistory().add(oldLocation, {message: `Save on focus lost [${oldLocation.type}]`})
+      this.getHistory().add(oldLocation, {message: `Save on focus lost [${oldLocation.command}]`})
       return
     }
 
@@ -204,7 +200,7 @@ module.exports = {
       row > atom.config.get("cursor-history.rowDeltaToRemember") ||
       (row === 0 && column > atom.config.get("cursor-history.columnDeltaToRemember"))
     ) {
-      this.getHistory().add(oldLocation, {message: `Cursor moved [${oldLocation.type}]`})
+      this.getHistory().add(oldLocation, {message: `Cursor moved [${oldLocation.command}]`})
     }
   },
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,7 +9,9 @@ const DefaultIgnoreCommands = [
 
 function getClosestEditorForTarget(target) {
   if (!target || !target.closest("atom-text-editor")) return
-  return target.closest("atom-text-editor").getModel()
+  const editor = target.closest("atom-text-editor").getModel()
+  // return editor
+  return !editor.isMini() ? editor : undefined
 }
 
 function createLocation(editor, command) {
@@ -48,6 +50,9 @@ module.exports = {
         },
         "cursor-history:prev-within-editor"() {
           jump(this.getModel(), "prev", {withinEditor: true})
+        },
+        "cursor-history:dump-history": () => {
+          this.getHistory().log("DUMP")
         },
         "cursor-history:clear": () => this.history && this.history.clear(),
         "cursor-history:toggle-debug": () => this.toggleDebug(),
@@ -181,8 +186,11 @@ module.exports = {
     const editor = atom.workspace.getActiveTextEditor()
     if (!editor) return
 
-    // if (!editor.element.hasFocus())  || editor.getURI() !== oldLocation.URI) {
-    if (!editor.element.hasFocus() || editor !== oldLocation.editor) {
+    if (
+      !editor.element.hasFocus() || oldLocation.URI
+        ? editor.getURI() !== oldLocation.URI
+        : editor !== oldLocation.editor
+    ) {
       this.getHistory().add(oldLocation, {message: `Save on focus lost [${oldLocation.command}]`})
       return
     }

--- a/spec/cursor-history-spec.js
+++ b/spec/cursor-history-spec.js
@@ -33,7 +33,7 @@ global.beforeEach(function() {
 describe("cursor-history", () => {
   let editor, editorElement, main, pathSample1, pathSample2, fakeClock
 
-  const getEntries = function(which = null) {
+  function getEntries(which = null) {
     const {entries} = main.history
     switch (which) {
       case "last":


### PR DESCRIPTION
Fix #37 
Related #16 (partially fix)


Allow track history for unsaved buffer.
Which means, cursor-history can go/back the history of file as long as the editor is alive.
So, nuclide remote file should be also trackable(I'm not using really check since I don' use remote edit environment).

Limitation: if file is not saved to **local-disk** the history entry is become unavailable when editor is destroyed.