### PR TITLE
Fix exception when cursor is focused on min-editor of project-find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.13.2:
+- Fix: mini editor was inappropriately saved as history and cause runtime exception. Now fixed.
+
 ## 0.13.1:
 - Fix: Debug command `cursor-history:dump-history` no longer throw exception.
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,7 +11,10 @@ const DEFAULT_IGNORE_COMMANDS = [
 
 function getClosestEditorForTarget (target) {
   if (target && target.closest('atom-text-editor')) {
-    return target.closest('atom-text-editor').getModel()
+    const editor = target.closest('atom-text-editor').getModel()
+    if (editor && !editor.isMini()) {
+      return editor
+    }
   }
 }
 
@@ -177,7 +180,7 @@ module.exports = {
 
   checkLocationChange (location, timeout) {
     if (!location) {
-      throw new Error('empty location now allowed for checkLocationChange()')
+      throw new Error('empty location now not allowed for checkLocationChange()')
     }
 
     return setTimeout(() => {


### PR DESCRIPTION
fix #40


@JobJob

`entry.URI` need to should not be mandatory so that cursor-history support unsaved temproal buffer.
The cause was saving hitrory for `mini` editor, which was unintentional, so I just make it ignore.