### PR TITLE
Add pending open config

### DIFF
--- a/lib/history.js
+++ b/lib/history.js
@@ -261,7 +261,10 @@ module.exports = class History {
       landingEditor = entry.editor
       isSameURI = true
     } else {
-      landingEditor = await atom.workspace.open(entry.URI, {searchAllPanes: getConfig('searchAllPanes')})
+      landingEditor = await atom.workspace.open(entry.URI, {
+        pending: getConfig('pendingOpen'),
+        searchAllPanes: getConfig('searchAllPanes')
+      })
       isSameURI = entry.URI === fromURI
     }
 

--- a/lib/history.js
+++ b/lib/history.js
@@ -262,7 +262,7 @@ module.exports = class History {
       isSameURI = true
     } else {
       landingEditor = await atom.workspace.open(entry.URI, {
-        pending: getConfig('pendingOpen'),
+        pending: getConfig('openInPendingState'),
         searchAllPanes: getConfig('searchAllPanes')
       })
       isSameURI = entry.URI === fromURI

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     },
     "pendingOpen": {
       "default": false,
-      "description": "Opens an new editor [in a pending state](https://atom.io/docs/api/AtomEnvironment#instance-open)",
+      "description": "Opens an new editor [in a pending state](https://atom.io/docs/api/v1.39.1/Workspace#instance-open)",
       "order": 6,
       "type": "boolean"
     },

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
       "order": 5,
       "type": "boolean"
     },
-    "pendingOpen": {
+    "openInPendingState": {
       "default": false,
-      "description": "Opens an new editor [in a pending state](https://atom.io/docs/api/v1.39.1/Workspace#instance-open)",
+      "description": "If the target location is not currently opened, open editor in pending-state (preview mode)",
       "order": 6,
       "type": "boolean"
     },

--- a/package.json
+++ b/package.json
@@ -53,10 +53,16 @@
       "order": 5,
       "type": "boolean"
     },
+    "pendingOpen": {
+      "default": false,
+      "description": "Opens an new editor [in a pending state](https://atom.io/docs/api/AtomEnvironment#instance-open)",
+      "order": 6,
+      "type": "boolean"
+    },
     "flashOnLand": {
       "default": true,
       "description": "flash cursor on land",
-      "order": 6,
+      "order": 7,
       "type": "boolean"
     },
     "ignoreCommands": {
@@ -67,12 +73,12 @@
         "type": "string"
       },
       "description": "list of commands to exclude from history tracking.",
-      "order": 7,
+      "order": 8,
       "type": "array"
     },
     "debug": {
       "default": false,
-      "order": 8,
+      "order": 9,
       "type": "boolean"
     }
   },


### PR DESCRIPTION
Thanks for this great package !

I would like to propose that this package allows an user to open an new editor [in a pending state](https://atom.io/docs/api/v1.39.1/Workspace#instance-open) in order to keep the workspace clean, preventing temporarily opened editors from staying there.